### PR TITLE
set eza icons attribute to ‘auto’

### DIFF
--- a/MacOS/flake.nix
+++ b/MacOS/flake.nix
@@ -172,7 +172,7 @@
             programs.eza = {
               enable = true;
               git = true;
-              icons = true;
+              icons = "auto";
             };
             programs.bat = {
               enable = true;


### PR DESCRIPTION
update in eza build settings deprecates true/false, needs ‘auto’